### PR TITLE
[ET-11] FIX: Add image to Product constructor

### DIFF
--- a/src/main/java/ca/epsilonlambda/shoppingcart/domain/Product.java
+++ b/src/main/java/ca/epsilonlambda/shoppingcart/domain/Product.java
@@ -26,10 +26,11 @@ public class Product {
     @Column(nullable = false)
     private String image;
 
-    public Product(String name, String description, float cost) {
+    public Product(String name, String description, float cost, String image) {
         this.name = name;
         this.description = description;
         this.price = cost;
+        this.image = image;
     }
 
     public Product() {}

--- a/src/test/java/ca/epsilonlambda/shoppingcart/data/ProductRepositoryTest.java
+++ b/src/test/java/ca/epsilonlambda/shoppingcart/data/ProductRepositoryTest.java
@@ -24,7 +24,7 @@ public class ProductRepositoryTest extends TestCase {
         final String testName = "testName";
         final String testDescription = "testDescription";
 
-        Product p = new Product(testName, testDescription, 1);
+        Product p = new Product(testName, testDescription, 1, "");
         repository.save(p);
 
         for(Product product : repository.findAll()) {


### PR DESCRIPTION
We have added the IMAGE column to the PRODUCT table as part of the
ProductTile enhancement. The column was specified as non-null, but the
test for /api/v1/products did not end up initializing the image field of
the entity it wanted to insert, causing a database integrity exception.

Going forward, every pull-request will have Snap CI build its branch to
check test status before merging into master.
